### PR TITLE
Fix for global listeners not being called.

### DIFF
--- a/events.go
+++ b/events.go
@@ -148,17 +148,13 @@ func (eo *eventObserver) Change(data []byte) error {
 	eo.lock.RLock()
 	defer eo.lock.RUnlock()
 
-	if eo.listeners != nil {
-		for _, listener := range eo.listeners[e.ID] {
-			//If the listeners do a lot of work ,kicking these off in goroutines might be worth
-			listener(e)
-		}
+	for _, listener := range eo.listeners[e.ID] {
+		//If the listeners do a lot of work ,kicking these off in goroutines might be worth
+		listener(e)
 	}
 
-	if eo.globalListeners != nil {
-		for _, globalListener := range eo.globalListeners {
-			globalListener(e)
-		}
+	for _, globalListener := range eo.globalListeners {
+		globalListener(e)
 	}
 
 	return nil

--- a/events.go
+++ b/events.go
@@ -131,6 +131,10 @@ type eventObserver struct {
 }
 
 func (eo *eventObserver) Change(data []byte) error {
+	if data == nil {
+		return nil
+	}
+
 	e := &Event{}
 
 	if eo.typer != nil {
@@ -144,21 +148,17 @@ func (eo *eventObserver) Change(data []byte) error {
 	eo.lock.RLock()
 	defer eo.lock.RUnlock()
 
-	if eo.listeners == nil {
-		return nil
+	if eo.listeners != nil {
+		for _, listener := range eo.listeners[e.ID] {
+			//If the listeners do a lot of work ,kicking these off in goroutines might be worth
+			listener(e)
+		}
 	}
 
-	for _, listener := range eo.listeners[e.ID] {
-		//If the listeners do a lot of work ,kicking these off in goroutines might be worth
-		listener(e)
-	}
-
-	if eo.globalListeners == nil {
-		return nil
-	}
-
-	for _, globalListener := range eo.globalListeners {
-		globalListener(e)
+	if eo.globalListeners != nil {
+		for _, globalListener := range eo.globalListeners {
+			globalListener(e)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
If there were no "normal" listeners registers (eo.listeners was nil) we'd be returning before giving a chance for the global listeners to be checked and called.

While testing I got rabbitmq in a weird state where it flooded the Change method with nil data. This went away and I couldn't reproduce it. I still left the data != nil check on top. Can't hurt, can it? (no seriously, let me know what you think.)