### PR TITLE
Extended the error logging when the handle function fails to handle the message

### DIFF
--- a/exchange.go
+++ b/exchange.go
@@ -281,7 +281,7 @@ func (re *RabbitExchangeImpl) Receive(exchange ExchangeSettings, queue QueueSett
 					// Do something
 					err = handler(m.Body)
 					if err != nil {
-						log.Printf("Error handling rabbit message Exchange: %s Queue: %s Body: [%s] %+v\n", exchange.Name, queue.Name, string(m.Body), err)
+						log.Printf("Error handling rabbit message Exchange: %s Queue: %s Body: [%s] %+v\n", exchange.Name, queue.Name, m.Body, err)
 						err = m.Nack(false, false)
 						if err != nil {
 							log.Printf("Error Nack rabbit message %+v\n", err)

--- a/exchange.go
+++ b/exchange.go
@@ -281,7 +281,7 @@ func (re *RabbitExchangeImpl) Receive(exchange ExchangeSettings, queue QueueSett
 					// Do something
 					err = handler(m.Body)
 					if err != nil {
-						log.Printf("Error handeling rabbit message %+v\n", err)
+						log.Printf("Error handling rabbit message Exchange: %s Queue: %s Body: [%s] %+v\n", exchange.Name, queue.Name, string(m.Body), err)
 						err = m.Nack(false, false)
 						if err != nil {
 							log.Printf("Error Nack rabbit message %+v\n", err)


### PR DESCRIPTION
Messages like this is not helpful enough in tracking down the culprit:
```
Sep 01 10:11:05 staging-kpc-2 kpc_core.log: Sep 1 08:11:05 ip-172-31-53-111 kpc.core[21954]: 2020/09/01 08:11:05 Error handeling rabbit message unknown field "Key" in core.ChatMessage 
```