### PR TITLE
The receive function now redials the connection if it is marked as cl…

### DIFF
--- a/exchange.go
+++ b/exchange.go
@@ -171,6 +171,13 @@ func (re *RabbitExchangeImpl) Receive(exchange ExchangeSettings, queue QueueSett
 			return nil, nil, func() {}, err
 		}
 
+		if conn.IsClosed() {
+			conn, err = re.newEventConnection(conn, re.rabbitIni)
+			if err != nil {
+				return nil, nil, func() {}, err
+			}
+		}
+
 		ch, err := conn.Channel()
 
 		if err != nil {


### PR DESCRIPTION
…osed (send already redails on error)


`getChannel` never redialed the connection, it only returned an error on the operations (the calling code then retried).
This means the calling code kept retrying on an old connection, that could never be fixed.  