### PR TITLE
Only log the caller of emit, and nothing else

### DIFF
--- a/events.go
+++ b/events.go
@@ -87,25 +87,15 @@ func (rem *ImplRabbitEventHandler) Emit(path string) EventEmitter {
 		}
 
 		callers := make([]uintptr, 30)
-		numCallers := runtime.Callers(1, callers)
+		numCallers := runtime.Callers(2, callers)
 		if numCallers > 1 {
 			frames := runtime.CallersFrames(callers)
-			for {
-				first, more := frames.Next()
+			first, _ := frames.Next()
+			event.Source.Originator += first.File + ":" + fmt.Sprint(first.Line) + " " + first.Function + "\n"
+		}
 
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-
-				event.Source.Originator += first.File + ":" + fmt.Sprint(first.Line) + " " + first.Function + "\n"
-
-				if !more {
-					break
-				}
-			}
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 
 		data, err := json.Marshal(event)


### PR DESCRIPTION
We currently log 
```
Originator":"/home/runner/go/pkg/mod/github.com/getkalido/rabbit-events@v0.0.0-20210513100834-0494740efdcc/events.go:82 github.com/getkalido/rabbit-events.(*ImplRabbitEventHandler).Emit.func1\n/home/runner/work/kpc/kpc/services/grpc/core/findExpertiseQuest/grpcFindExpertiseQuestRequirementService.go:81 github.com/getkalido/kpc/services/grpc/core/findExpertiseQuest.(*FindExpertiseQuestRequirementService).CreateFindExpertiseQuestRequirement\n/home/runner/work/kpc/kpc/proto/core/find_expertise_quest.pb.go:3993 github.com/getkalido/proto/core._FindExpertiseQuestRequirementService_CreateFindExpertiseQuestRequirement_Handler.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/auth/auth.go:47 github.com/grpc-ecosystem/go-grpc-middleware/auth.UnaryServerInterceptor.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/recovery/interceptors.go:30 github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/tracing/opentracing/server_interceptors.go:31 github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing.UnaryServerInterceptor.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/work/kpc/kpc/services/grpc/grpc.go:380 github.com/getkalido/kpc/services/grpc.UnaryTokenAdder.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/work/kpc/kpc/services/grpc/grpc.go:339 github.com/getkalido/kpc/services/grpc.UnaryContextLogOnError.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/work/kpc/kpc/services/grpc/grpc.go:319 github.com/getkalido/kpc/services/grpc.UnaryErrorCodeUnnest.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/logging/zap/payload_interceptors.go:34 github.com/grpc-ecosystem/go-grpc-middleware/logging/zap.PayloadUnaryServerInterceptor.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/logging/zap/server_interceptors.go:32 github.com/grpc-ecosystem/go-grpc-middleware/logging/zap.UnaryServerInterceptor.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/tags/interceptors.go:22 github.com/grpc-ecosystem/go-grpc-middleware/tags.UnaryServerInterceptor.func1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1\n/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:34 github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1\n/home/runner/work/kpc/kpc/proto/core/find_expertise_quest.pb.go:3995 github.com/getkalido/proto/core._FindExpertiseQuestRequirementService_CreateFindExpertiseQuestRequirement_Handler\n/home/runner/go/pkg/mod/google.golang.org/grpc@v1.25.1/server.go:1007 google.golang.org/grpc.(*Server).processUnaryRPC\n/home/runner/go/pkg/mod/google.golang.org/grpc@v1.25.1/server.go:1287 google.golang.org/grpc.(*Server).handleStream\n/home/runner/go/pkg/mod/google.golang.org/grpc@v1.25.1/server.go:722 google.golang.org/grpc.(*Server).serveStreams.func1.1\n/opt/hostedtoolcache/go/1.15.8/x64/src/runtime/asm_amd64.s:1374 runtime.goexit\n
```
This PR should change that to 
```
home/runner/work/kpc/kpc/services/grpc/core/findExpertiseQuest/grpcFindExpertiseQuestRequirementService.go:81 github.com/getkalido/kpc/services/grpc/core/findExpertiseQuest.(*FindExpertiseQuestRequirementService).CreateFindExpertiseQuestRequirement\n
```

The advantage is smaller messages (better performance on rabbitmq), and smaller logs when the event processors fail to process the messages (more detail in the errors, since the messages get capped). 


The obvious downside is that we dont have the entire stack, so figuring out run-away emits might be harder (but I am thinking traces should give us enough insights to not run into this, but that is a hypothesis). 