### PR TITLE
No longer send context in events

### DIFF
--- a/events.go
+++ b/events.go
@@ -80,11 +80,9 @@ func (rem *ImplRabbitEventHandler) Emit(path string) EventEmitter {
 			Path:   path,
 			Action: action,
 			ID:     id,
-			Source: EventSource{
-				Context: context,
-			},
-			Old:   old,
-			State: state,
+			Source: EventSource{},
+			Old:    old,
+			State:  state,
 		}
 
 		callers := make([]uintptr, 30)


### PR DESCRIPTION
<img width="1064" alt="image" src="https://user-images.githubusercontent.com/73693344/166745884-40aa8005-02ad-4832-a3a4-dd57a6acae22.png">


I think this will speed up sending/receiving events by 20% (maybe more, since we will be allocating less, and sending fewer bytes over all). 