### PR TITLE
Fix error when marshalling headers.

### DIFF
--- a/events.go
+++ b/events.go
@@ -87,7 +87,10 @@ func (rem *ImplRabbitEventHandler) sendEvent(
 	paths map[string]int64,
 ) error {
 	messageHeaders := map[string]interface{}{
-		EventActionHeaderKey: action,
+		// Must be explicitly made one of the types supported by AMQP, since
+		// the library doesn't provide an interface to convert values to
+		// supported types.
+		EventActionHeaderKey: string(action),
 	}
 	lastPath := ""
 	lastID := int64(0)


### PR DESCRIPTION
Ticket:
https://teamkalido.monday.com/boards/1476701509/pulses/2326631991

Without this change, the `streadway/amqp` library throws an error when attempting to publish events. The problem is that `ActionType` is an enum and is not supported by the library, so it must be explicitly converted to a supported type _before_ publishing.