### PR TITLE
Fix a single consumer getting all messages.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,14 +14,14 @@ jobs:
   build:
     services:
       rabbitmq:
-        image: rabbitmq:3.7-alpine
+        image: rabbitmq:3.9-alpine
         ports:
           - 5672:5672
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Set up Go 1.15.8
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.15.8
       id: go

--- a/events.go
+++ b/events.go
@@ -183,21 +183,28 @@ func (rem *ImplRabbitEventHandler) EmitMultiple(paths []string) MultiEventEmitte
 }
 
 func (rem *ImplRabbitEventHandler) Consume(path string, typer ...func() interface{}) (EventConsumer, error) {
-	receive, stop, bind, unbind, err := rem.rabbitEx.ReceiveMultiple(ExchangeSettings{
-		Name:         rem.exchangeName,
-		ExchangeType: ExchangeTypeHeaders,
-		Durable:      true,
-		AutoDelete:   false,
-		Exclusive:    false,
-		NoWait:       false,
-		Args:         nil,
-	}, QueueSettings{
-		Name:       "",
-		RoutingKey: "",
-		AutoDelete: true,
-		Exclusive:  false,
-		Prefetch:   rem.prefetchCount,
-	})
+	receive, stop, bind, unbind, err := rem.rabbitEx.ReceiveMultiple(
+		ExchangeSettings{
+			Name:         rem.exchangeName,
+			ExchangeType: ExchangeTypeHeaders,
+			Durable:      true,
+			AutoDelete:   false,
+			Exclusive:    false,
+			NoWait:       false,
+			Args:         nil,
+		},
+		QueueSettings{
+			Name:       "",
+			RoutingKey: "",
+			AutoDelete: true,
+			Exclusive:  false,
+			Prefetch:   rem.prefetchCount,
+			BindArgs: map[string]interface{}{
+				"x-match": "any",
+				fmt.Sprintf("%s-%s", EventPathHeaderKey, path): true,
+			},
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -217,21 +224,24 @@ func (rem *ImplRabbitEventHandler) Consume(path string, typer ...func() interfac
 
 func (rem *ImplRabbitEventHandler) ConsumeMultiple(typer ...func() interface{}) (MultiEventConsumer, error) {
 
-	receive, stop, bind, unbind, err := rem.rabbitEx.ReceiveMultiple(ExchangeSettings{
-		Name:         rem.exchangeName,
-		ExchangeType: ExchangeTypeHeaders,
-		Durable:      true,
-		AutoDelete:   false,
-		Exclusive:    false,
-		NoWait:       false,
-		Args:         nil,
-	}, QueueSettings{
-		Name:       "",
-		RoutingKey: "",
-		AutoDelete: true,
-		Exclusive:  true,
-		Prefetch:   rem.prefetchCount,
-	})
+	receive, stop, bind, unbind, err := rem.rabbitEx.ReceiveMultiple(
+		ExchangeSettings{
+			Name:         rem.exchangeName,
+			ExchangeType: ExchangeTypeHeaders,
+			Durable:      true,
+			AutoDelete:   false,
+			Exclusive:    false,
+			NoWait:       false,
+			Args:         nil,
+		},
+		QueueSettings{
+			Name:       "",
+			RoutingKey: "",
+			AutoDelete: true,
+			Exclusive:  true,
+			Prefetch:   rem.prefetchCount,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/exchange.go
+++ b/exchange.go
@@ -336,20 +336,6 @@ func (re *RabbitExchangeImpl) ReceiveMultiple(
 			return nil, nil, nil, closeChan, err
 		}
 
-		err = ch.ExchangeDeclare(
-			retryExchangeName, // name
-			retryExchangeType, // type
-			true,              // durable
-			false,             // delete when unused
-			false,             // exclusive
-			false,             // no-wait
-			nil,               // args
-		)
-
-		if err != nil {
-			return nil, nil, nil, closeChan, err
-		}
-
 		q, err := ch.QueueDeclare(
 			queue.Name,       // name
 			queue.Durable,    // durable

--- a/exchange.go
+++ b/exchange.go
@@ -336,6 +336,20 @@ func (re *RabbitExchangeImpl) ReceiveMultiple(
 			return nil, nil, nil, closeChan, err
 		}
 
+		err = ch.ExchangeDeclare(
+			retryExchangeName, // name
+			retryExchangeType, // type
+			true,              // durable
+			false,             // delete when unused
+			false,             // exclusive
+			false,             // no-wait
+			nil,               // args
+		)
+
+		if err != nil {
+			return nil, nil, nil, closeChan, err
+		}
+
 		q, err := ch.QueueDeclare(
 			queue.Name,       // name
 			queue.Durable,    // durable


### PR DESCRIPTION
When connecting to a new headers exchange, it received _all_ messages, regardless of route. This PR should cause the old code to work as expected.